### PR TITLE
Align Netlify Hugo + remove timestamp cache busting

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -83,14 +83,13 @@
 	<!-- theme meta -->
 	<meta name="theme-name" content="Christian Guzman Hugo Theme" />
 	{{ hugo.Generator }}
-	{{ $assetVersion := now.Unix }}
 
 	{{ "<!-- plugins -->" | safeHTML }}
 	{{ range site.Params.plugins.css }}
 	{{ if or (hasPrefix .link "http://") (hasPrefix .link "https://") }}
 	<link rel="stylesheet" href="{{ .link | absURL }}">
 	{{ else }}
-	<link rel="stylesheet" href="{{ printf "%s?v=%d" (.link | absURL) $assetVersion }}">
+	<link rel="stylesheet" href="{{ .link | absURL }}">
 	{{ end }}
 	{{ end }}
 
@@ -124,12 +123,12 @@
 	{{ end }}
 
 	{{ "<!--Favicon-->" | safeHTML }}
-	<link rel="icon" type="image/png" sizes="32x32" href="{{ printf "%s?v=%d" (`images/icons/favicon-32x32.png` | absURL) $assetVersion }}">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ printf "%s?v=%d" (`images/icons/favicon-16x16.png` | absURL) $assetVersion }}">
-  <link rel="shortcut icon" type="image/png" href="{{ printf "%s?v=%d" (`images/icons/favicon-32x32.png` | absURL) $assetVersion }}" />
+	<link rel="icon" type="image/png" sizes="32x32" href="{{ `images/icons/favicon-32x32.png` | absURL }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ `images/icons/favicon-16x16.png` | absURL }}">
+  <link rel="shortcut icon" type="image/png" href="{{ `images/icons/favicon-32x32.png` | absURL }}" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ printf "%s?v=%d" (`images/icons/apple-touch-icon.png` | absURL) $assetVersion }}">
-  <link rel="manifest" href="{{ printf "/site.webmanifest?v=%d" $assetVersion }}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ `images/icons/apple-touch-icon.png` | absURL }}">
+  <link rel="manifest" href="/site.webmanifest">
 
 	{{ partial "analytics.html" . }}
 	<script src="https://analytics.ahrefs.com/analytics.js" data-key="A5YQA1IobngQ0vKl+SpY8g" async></script>

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -1,0 +1,40 @@
+{{ "<!-- Google Map API -->" | safeHTML }}
+{{ if site.Params.map.enable }}
+<script src="{{ site.Params.map.gmap_api | safeURL }}"></script>
+{{ end }}
+
+{{ "<!-- JS Plugins -->" | safeHTML }}
+{{ range site.Params.plugins.js}}
+{{ if or (hasPrefix .link "http://") (hasPrefix .link "https://") }}
+<script src="{{ .link | absURL }}"></script>
+{{ else }}
+<script src="{{ .link | absURL }}"></script>
+{{ end }}
+{{ end }}
+
+{{ "<!-- Main Script -->" | safeHTML }}
+{{ $script := resources.Get "js/script.js" | minify | fingerprint "sha384"}}
+<script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity }}"></script>
+
+<!-- cookie -->
+{{ if site.Params.cookies.enable }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+<div id="js-cookie-box" class="cookie-box cookie-box-hide">
+	This site uses cookies. By continuing to use this website, you agree to their use. <span id="js-cookie-button" class="btn btn-transparent">I Accept</span>
+</div>
+<script>
+	(function ($) {
+		const cookieBox = document.getElementById('js-cookie-box');
+		const cookieButton = document.getElementById('js-cookie-button');
+		if (!Cookies.get('cookie-box')) {
+			cookieBox.classList.remove('cookie-box-hide');
+			cookieButton.onclick = function () {
+				Cookies.set('cookie-box', true, {
+					expires: {{ site.Params.cookies.expire_days }}
+				});
+				cookieBox.classList.add('cookie-box-hide');
+			};
+		}
+	})(jQuery);
+</script>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.150.0"
+  HUGO_VERSION = "0.155.1"
   HUGO_UMAMI_WEBSITE_ID = "54ba9f61-ea93-41db-a5e1-3e74b41605da"
   HUGO_UMAMI_SCRIPT_URL = "/stats/script.js"
   HUGO_UMAMI_DOMAINS = "christianguzman.uk"

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -80,6 +80,10 @@ describe('SEO build assertions', () => {
   for (const page of htmlFiles) {
     it(`validates ${page.relativePath}`, () => {
       const html = fs.readFileSync(page.absolutePath, 'utf8');
+      assert(
+        !/\?v=\d{10,}/.test(html),
+        `[${page.relativePath}] must not contain timestamp-based cache busting (?v=now.Unix style).`,
+      );
       const $ = load(html);
       const pageType = classifyPage(page.relativePath);
       const h1Count = $('h1').length;


### PR DESCRIPTION
## Summary\n- Aligns Netlify Hugo version with repo/CI.\n- Removes timestamp-based cache-busting (now.Unix ?v=...) from plugin CSS/JS and favicon/manifest links.\n- Adds an SEO test guardrail to prevent timestamp query params from coming back.\n\n## Verification\n- npm run test:seo\n\nCloses #37, #38