### PR TITLE
Netlify: cache /images immutably

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -74,7 +74,7 @@
 [[headers]]
   for = "/images/*"
   [headers.values]
-    Cache-Control = "public, max-age=3600, must-revalidate"
+    Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
   for = "/plugins/*"


### PR DESCRIPTION
## Summary\n- Updates Netlify headers for /images/* to long-lived immutable caching.\n\nCloses #36