### PR TITLE
[SEO] Add twitter:site and twitter:creator metadata

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -237,6 +237,10 @@ RSS = true                   # LoveIt NEW | 0.2.0
 [params.seo]
 # default site description used for metadata and WebSite JSON-LD
 siteDescription = "Christian Guzman helps engineering leaders build resilient organisations through coaching, systems thinking, and human-centred technical leadership."
+# Optional Twitter/X handles for Twitter Card metadata.
+# Expected format: "@handle" (kept as-is; no normalization).
+twitterSite = ""
+twitterCreator = ""
 # image URL
 image = "/images/social/og-default.jpg"
 # thumbnail URL

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -79,6 +79,15 @@
 	<meta name="twitter:card" content="{{ if $socialImage }}summary_large_image{{ else }}summary{{ end }}">
 	<meta name="twitter:title" content="{{ $title }}">
 	<meta name="twitter:description" content="{{ $description }}">
+	{{ $twitterSite := site.Params.seo.twitterSite | default "" | plainify | htmlUnescape | strings.TrimSpace }}
+	{{ $twitterCreator := site.Params.seo.twitterCreator | default "" | plainify | htmlUnescape | strings.TrimSpace }}
+	{{ if $twitterSite }}
+	<meta name="twitter:site" content="{{ $twitterSite }}">
+	{{ end }}
+	{{ $twitterCreatorEffective := $twitterCreator | default $twitterSite }}
+	{{ if $twitterCreatorEffective }}
+	<meta name="twitter:creator" content="{{ $twitterCreatorEffective }}">
+	{{ end }}
 	{{ with $socialImage }}
 	<meta name="twitter:image" content="{{ . }}">
 	{{ end }}

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -14,7 +14,7 @@ const SERVICE_SCHEMA_TYPES = new Set(['Service']);
 const LANGUAGE_HOME_SEGMENTS = new Set(['en', 'english', 'fr']);
 const LEGACY_PUBLIC_SEGMENTS = ['/english/', '/en/', '/fr/'];
 
-const { baseUrl, siteTitle } = readHugoConfig(HUGO_CONFIG_PATH);
+const { baseUrl, siteTitle, twitterSite, twitterCreator } = readHugoConfig(HUGO_CONFIG_PATH);
 const netlifyConfig = fs.readFileSync(NETLIFY_CONFIG_PATH, 'utf8');
 const htmlFiles = fs.existsSync(PUBLIC_DIR)
   ? walkHtmlFiles(PUBLIC_DIR)
@@ -144,6 +144,35 @@ describe('SEO build assertions', () => {
       const twitterDescription = readRequiredMeta($, 'twitter:description', page.relativePath);
       readRequiredMeta($, 'twitter:card', page.relativePath);
 
+      if (twitterSite) {
+        assert(
+          readRequiredMeta($, 'twitter:site', page.relativePath) === twitterSite,
+          `[${page.relativePath}] twitter:site must match hugo.toml params.seo.twitterSite. Expected "${twitterSite}".`,
+        );
+      } else {
+        assert(
+          readOptionalMeta($, 'twitter:site') === null,
+          `[${page.relativePath}] twitter:site must not be emitted when params.seo.twitterSite is empty.`,
+        );
+      }
+
+      if (twitterCreator) {
+        assert(
+          readRequiredMeta($, 'twitter:creator', page.relativePath) === twitterCreator,
+          `[${page.relativePath}] twitter:creator must match hugo.toml params.seo.twitterCreator. Expected "${twitterCreator}".`,
+        );
+      } else if (twitterSite) {
+        assert(
+          readRequiredMeta($, 'twitter:creator', page.relativePath) === twitterSite,
+          `[${page.relativePath}] twitter:creator must fall back to params.seo.twitterSite. Expected "${twitterSite}".`,
+        );
+      } else {
+        assert(
+          readOptionalMeta($, 'twitter:creator') === null,
+          `[${page.relativePath}] twitter:creator must not be emitted when params.seo.twitterCreator and twitterSite are empty.`,
+        );
+      }
+
       const ogImage = readOptionalMeta($, 'og:image');
       if (ogImage !== null) {
         assertResolvableAssetUrl(
@@ -254,6 +283,8 @@ function readHugoConfig(configPath) {
   const config = fs.readFileSync(configPath, 'utf8');
   const baseUrlRaw = readTopLevelTomlString(config, 'baseURL');
   const siteTitle = readTopLevelTomlString(config, 'title');
+  const twitterSite = readTomlSectionString(config, 'params.seo', 'twitterSite');
+  const twitterCreator = readTomlSectionString(config, 'params.seo', 'twitterCreator');
 
   assert(baseUrlRaw, `Could not read baseURL from ${configPath}.`);
   assert(siteTitle, `Could not read title from ${configPath}.`);
@@ -261,12 +292,41 @@ function readHugoConfig(configPath) {
   return {
     baseUrl: new URL(baseUrlRaw),
     siteTitle,
+    twitterSite,
+    twitterCreator,
   };
 }
 
 function readTopLevelTomlString(config, key) {
   const match = config.match(new RegExp(`^${key}\\s*=\\s*["']([^"']+)["']`, 'm'));
   return match ? match[1].trim() : '';
+}
+
+function readTomlSectionString(config, section, key) {
+  let currentSection = '';
+  for (const rawLine of config.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    if (line.startsWith('[') && line.endsWith(']')) {
+      currentSection = line.slice(1, -1).trim();
+      continue;
+    }
+
+    if (currentSection !== section) {
+      continue;
+    }
+
+    const match = rawLine.match(new RegExp(`^\\s*${key}\\s*=\\s*["']([^"']*)["']`));
+    if (match) {
+      return match[1].trim();
+    }
+  }
+
+  return '';
 }
 
 function walkHtmlFiles(directory) {


### PR DESCRIPTION
Implements #39.

- Adds optional `params.seo.twitterSite` / `params.seo.twitterCreator` config.
- Emits `twitter:site` and `twitter:creator` meta tags only when configured (creator falls back to site).
- Extends `tests/seo-build.test.mjs` to assert presence/absence across all generated pages.

Tested: `npm run test:seo`