### PR TITLE
[Performance] Fix /articles/ LCP image discovery (eager + fetchpriority)

### DIFF
--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -2,14 +2,19 @@
   <div class="post-block">
     <div class="media-wrapper">
       <a href="{{ .Permalink }}">
+      {{ $aboveFold := .Scratch.Get "aboveFoldCard" }}
+      {{ $isLcp := .Scratch.Get "lcpCard" }}
       {{ partial "image.html" (dict
         "Src" .Params.Image
         "Alt" "Image"
-        "Class" "img-fluid lozad img-blog"
+        "Class" (cond $aboveFold "img-fluid img-blog" "img-fluid lozad img-blog")
+        "Loading" (cond $aboveFold "eager" "lazy")
+        "FetchPriority" (cond $isLcp "high" "")
         "DisplayXL" "800x"
         "DisplayLG" "640x"
         "DisplayMD" "480x"
         "DisplaySM" "360x"
+        "Context" .
       ) }}
       </a>
     </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,8 +18,14 @@
       </div>
       {{"<!-- /section title -->" | safeHTML}}
       {{ $paginator := .Paginate .Data.Pages 9 }}
-      {{ range $paginator.Pages }}
-      {{ .Render "article" }}
+      {{ range $i, $page := $paginator.Pages }}
+      {{ if and (hasPrefix $.RelPermalink "/articles/") (lt $i 3) }}
+        {{ $page.Scratch.Set "aboveFoldCard" true }}
+        {{ if eq $i 0 }}
+          {{ $page.Scratch.Set "lcpCard" true }}
+        {{ end }}
+      {{ end }}
+      {{ $page.Render "article" }}
       {{ end }}
       <div class="col-12">
         {{ template "_internal/pagination.html" . }}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -1,0 +1,285 @@
+{{ $image:= . }}
+{{ $imagePath:= .Src }}
+{{ $class:= .Class }}
+{{ $size:= .Size }}
+{{ $alt:= .Alt }}
+{{ $displayXL:= .DisplayXL | default "1110x" }}
+{{ $displayLG:= .DisplayLG | default "700x" }}
+{{ $displayMD:= .DisplayMD | default "600x" }}
+{{ $displaySM:= .DisplaySM | default "545x" }}
+{{ $resize:= .Resize | default true }}
+{{ $loading:= .Loading | default "lazy" }}
+{{ $context:= .Context | default . }}
+{{ $contentImage:= false }}
+{{ $assetImage:= false }}
+{{ $sizeValue:= index (split $size ` `) 0 }}
+{{ $height:= index (split $sizeValue `x`) 1 }}
+{{ $width:= index (split $sizeValue `x`) 0 }}
+{{ $webp:= .Webp | default true }}
+{{ $command:= .Command | default "Resize" }}
+{{ $placeholder:= .Placeholder | default false }}
+{{ $placeholderQuality:= "40x q20" }}
+{{ $fetchPriority:= .FetchPriority | default "" }}
+
+
+<!-- check content image  -->
+{{ with $context.Resources.GetMatch $imagePath }}
+  {{ $contentImage = true }}
+{{ end }}
+<!-- /check content image -->
+
+<!-- check asset image -->
+{{ if and (not (strings.HasPrefix $imagePath "http")) (fileExists (add `assets/` (string $imagePath))) }}
+  {{ $assetImage = true }}
+{{ end }}
+<!-- /check asset image -->
+
+<!-- image static/CDN -->
+{{ if or (hasPrefix $imagePath "http") (fileExists (add `static/` (string $imagePath))) }}
+  <img
+    loading="{{ .Loading }}"
+    decoding="async"
+    {{ with $fetchPriority }}fetchpriority="{{ . }}"{{ end }}
+    src="{{ $imagePath | absURL }}"
+    alt="{{ .Alt }}"
+    class="{{ $class }} img"
+    height="{{ $height }}"
+    width="{{ $width }}" />
+{{ else }}
+  <!-- /image cdn -->
+
+  <!-- check file existence -->
+  {{ if or $assetImage $contentImage }}
+    {{ if $assetImage }}
+      {{ $image = resources.Get $imagePath }}
+    {{ else if $contentImage }}
+      {{ $image = $context.Resources.GetMatch $imagePath }}
+    {{ end }}
+
+
+    <!-- image extension -->
+    {{ $imageExt := path.Ext $image }}
+
+
+    <!-- image height, width (if not svg) -->
+    {{ if eq $imageExt `.svg` }}
+      {{ .Scratch.Set "image-height" "" }}
+      {{ .Scratch.Set "image-width" "" }}
+    {{ else }}
+      {{ .Scratch.Set "image-height" $image.Height }}
+      {{ .Scratch.Set "image-width" $image.Width }}
+    {{ end }}
+    {{ $imageHeight:= .Scratch.Get "image-height" }}
+    {{ $imageWidth:= .Scratch.Get "image-width" }}
+
+
+    <!-- gif/svg image -->
+    {{ if or (eq $imageExt `.gif`) (eq $imageExt `.svg`) }}
+      <img
+        src="{{ $image.RelPermalink }}"
+        loading="{{ $loading }}"
+        decoding="async"
+        {{ with $fetchPriority }}fetchpriority="{{ . }}"{{ end }}
+        alt="{{ .Alt }}"
+        class="{{ $class }} img"
+        width="{{ $width }}"
+        height="{{ $height }}" />
+    {{ else }}
+      <!-- single image -->
+      {{ if $size }}
+        <!-- resize -->
+        {{ $imageFallback:= $image.Resize $size }}
+        {{ $imageWebp:= $image.Resize (add (string $size) " webp") }}
+        {{ if not $webp }}
+          {{ $imageWebp = $image.Resize (string $size) }}
+        {{ end }}
+        <!-- fit -->
+        {{ if eq $command "Fit" }}
+          {{ $imageFallback = $image.Fit $size }}
+          {{ $imageWebp = $image.Fit (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Fit (string $size) }}
+          {{ end }}
+          <!-- fill -->
+        {{ else if eq $command "Fill" }}
+          {{ $imageFallback = $image.Fill $size }}
+          {{ $imageWebp = $image.Fill (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Fill (string $size) }}
+          {{ end }}
+          <!-- crop -->
+        {{ else if eq $command "Crop" }}
+          {{ $imageFallback = $image.Crop $size }}
+          {{ $imageWebp = $image.Crop (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Crop (string $size) }}
+          {{ end }}
+        {{ end }}
+
+
+        <!-- placeholder -->
+        {{ $placeholderImage := ($imageWebp.Resize $placeholderQuality) | images.Filter (images.GaussianBlur 5) }}
+
+
+        <img
+          {{ if $placeholder }}
+            src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+            data-src={{ $imageWebp.RelPermalink }}
+          {{ else }}
+            src="{{ $imageWebp.RelPermalink }}" loading="{{ $loading }}"
+            decoding="async"
+          {{ end }}
+
+          alt="{{ .Alt }}"
+          {{ with $fetchPriority }}fetchpriority="{{ . }}"{{ end }}
+          class="{{ if $placeholder }}lazy{{ end }} {{ $class }} img"
+          width="{{- with $width -}}
+            {{- . -}}
+          {{- else -}}
+            {{- $imageWebp.Width -}}
+          {{- end -}}
+          "
+          height="{{- with $height -}}
+            {{- . -}}
+          {{- else -}}
+            {{- $imageWebp.Height -}}
+          {{- end -}}
+          "
+          onerror="this.onerror='null';
+          this.src='{{ $imageFallback.RelPermalink }}';" />
+
+        <!-- if image size less then 500x and size not defined -->
+      {{ else if or (lt ($image.Width) 500) (not $resize) }}
+        {{ $size:= add (add (string $image.Width) "x") (string $image.Height) }}
+        <!-- resize -->
+        {{ $imageWebp:= $image.Resize (add (string $size) " webp") }}
+        {{ if not $webp }}
+          {{ $imageWebp = $image.Resize (string $size) }}
+        {{ end }}
+        <!-- fit -->
+        {{ if eq $command "Fit" }}
+          {{ $imageWebp = $image.Resize (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Resize (string $size) }}
+          {{ end }}
+          <!-- fill -->
+        {{ else if eq $command "Fill" }}
+          {{ $imageWebp = $image.Resize (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Resize (string $size) }}
+          {{ end }}
+          <!-- crop -->
+        {{ else if eq $command "Crop" }}
+          {{ $imageWebp = $image.Resize (add (string $size) " webp") }}
+          {{ if not $webp }}
+            {{ $imageWebp = $image.Resize (string $size) }}
+          {{ end }}
+        {{ end }}
+
+
+        <!-- placeholder -->
+        {{ $placeholderImage := ($imageWebp.Resize $placeholderQuality) | images.Filter (images.GaussianBlur 5) }}
+
+
+        <img
+          {{ if $placeholder }}
+            src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+            data-src={{ $imageWebp.RelPermalink }} alt="placeholder"
+          {{ else }}
+            src="{{ $imageWebp.RelPermalink }}" loading="{{ $loading }}"
+            decoding="async" alt="{{ .Alt }}"
+          {{ end }}
+
+          {{ with $fetchPriority }}fetchpriority="{{ . }}"{{ end }}
+          class="{{ if $placeholder }}lazy{{ end }} {{ $class }} img"
+          width="{{- with $width -}}
+            {{- . -}}
+          {{- else -}}
+            {{- $imageWebp.Width -}}
+          {{- end -}}
+          "
+          height="{{- with $height -}}
+            {{- . -}}
+          {{- else -}}
+            {{- $imageWebp.Height -}}
+          {{- end -}}
+          "
+          onerror="this.onerror='null';this.src='{{ $image.RelPermalink }}';" />
+      {{ else }}
+        <!-- /if image size less then 500x and size not defined -->
+
+        <!-- image processing for multiple device -->
+        {{ $imageFallback:= $image.Resize $displayXL }}
+        {{ $imageXL:= $image.Resize (add $displayXL " webp") }}
+        {{ $imageLG:= $image.Resize (add $displayLG " webp") }}
+        {{ $imageMD:= $image.Resize (add $displayMD " webp") }}
+        {{ $imageSM:= $image.Resize (add $displaySM " webp") }}
+        {{ if not $webp }}
+          {{ $imageXL = $image.Resize $displayXL }}
+          {{ $imageLG = $image.Resize $displayLG }}
+          {{ $imageMD = $image.Resize $displayMD }}
+          {{ $imageSM = $image.Resize $displaySM }}
+        {{ end }}
+
+
+        <!-- placeholder -->
+        {{ $placeholderImage := ($imageFallback.Resize $placeholderQuality) | images.Filter (images.GaussianBlur 5) }}
+
+
+        <picture>
+          <source
+            {{ if $placeholder }}
+              src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+              data-srcset={{ $imageFallback.RelPermalink }}
+            {{ else }}
+              srcset="{{ $imageSM.RelPermalink }}"
+            {{ end }}
+            media="(max-width: 575px)" />
+          <source
+            {{ if $placeholder }}
+              src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+              data-srcset={{ $imageFallback.RelPermalink }}
+            {{ else }}
+              srcset="{{ $imageMD.RelPermalink }}"
+            {{ end }}
+            media="(max-width: 767px)" />
+          <source
+            {{ if $placeholder }}
+              src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+              data-srcset={{ $imageFallback.RelPermalink }}
+            {{ else }}
+              srcset="{{ $imageLG.RelPermalink }}"
+            {{ end }}
+            media="(max-width: 991px)" />
+          <source
+            {{ if $placeholder }}
+              src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+              data-srcset={{ $imageFallback.RelPermalink }}
+            {{ else }}
+              srcset="{{ $imageXL.RelPermalink }}"
+            {{ end }} />
+          <img
+            {{ if $placeholder }}
+              src="data:image/jpeg;base64,{{ $placeholderImage.Content | base64Encode }}"
+              data-src={{ $imageFallback.RelPermalink }}
+            {{ else }}
+              loading="{{ $loading }}" decoding="async"
+              src="{{ $imageFallback.RelPermalink }}"
+            {{ end }}
+            {{ with $fetchPriority }}fetchpriority="{{ . }}"{{ end }}
+            class="{{ if $placeholder }}
+              lazy
+            {{ end }} {{ $class }} img"
+            alt="{{ .Alt }}"
+            width="{{ $image.Width }}"
+            height="{{ $image.Height }}" />
+        </picture>
+      {{ end }}
+      <!-- end image processing -->
+    {{ end }}
+    <!-- end single image -->
+  {{ end }}
+
+
+  <!-- end check file existence -->
+{{ end }}

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -231,6 +231,35 @@ describe('SEO build assertions', () => {
         );
       }
 
+      if (page.relativePath === 'articles/index.html') {
+        const articleImages = $('.media-wrapper img.img-blog').slice(0, 3);
+        assert(
+          articleImages.length === 3,
+          `[${page.relativePath}] must render at least 3 article card images for the above-the-fold eager loading assertions.`,
+        );
+
+        articleImages.each((index, element) => {
+          const img = $(element);
+          const className = img.attr('class') ?? '';
+          assert(
+            !className.split(/\s+/).includes('lozad'),
+            `[${page.relativePath}] above-the-fold article card image ${index + 1} must not include the \"lozad\" class.`,
+          );
+          const loading = img.attr('loading')?.trim() ?? '';
+          assert(
+            loading === 'eager',
+            `[${page.relativePath}] above-the-fold article card image ${index + 1} must use loading=\"eager\". Actual value: \"${loading}\".`,
+          );
+        });
+
+        const firstImage = articleImages.first();
+        const fetchPriority = firstImage.attr('fetchpriority')?.trim() ?? '';
+        assert(
+          fetchPriority === 'high',
+          `[${page.relativePath}] first above-the-fold article card image must use fetchpriority=\"high\". Actual value: \"${fetchPriority}\".`,
+        );
+      }
+
       const schemas = readStructuredData($, page.relativePath);
       const schemaTypes = collectSchemaTypes(schemas);
       const hasArticleSchema = schemaTypes.some((type) => ARTICLE_SCHEMA_TYPES.has(type));


### PR DESCRIPTION
Closes #50.

- Marks first 3 cards on `/articles/` as above-the-fold and renders their images without `lozad` + `loading="eager"`.
- Adds `fetchpriority="high"` to the first card image.
- Overrides `layouts/partials/image.html` to support an optional `FetchPriority` param without affecting existing calls.
- Adds SEO build assertions to prevent regressions.

Tested: `npm run test:seo`.

Post-deploy verification
- Run `npm run audit` and confirm `/articles/` no longer reports `lcp-discovery-insight` with lazy-load applied / missing fetchpriority for the LCP image.