### PR TITLE
[P3] Reduce unused JS and optimize blog card images

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,150 +1,181 @@
-/* ========================================================================= */
-/*	Page Preloader
-/* ========================================================================= */
+(() => {
+  'use strict';
 
-$(window).on('load', function () {
-	$('.preloader').fadeOut(100);
-});
+  function hidePreloader() {
+    const preloader = document.querySelector('.preloader');
+    if (!preloader) return;
+    preloader.style.display = 'none';
+  }
 
-jQuery(function ($) {
-	"use strict";
+  function initLazyLoad() {
+    if (typeof window.lozad !== 'function') return;
+    const observer = window.lozad();
+    observer.observe();
+  }
 
-	/* ========================================================================= */
-	/*	lazy load initialize
-	/* ========================================================================= */
+  function scrollToTarget(target) {
+    const offset = 50;
+    const top = target.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top, behavior: 'smooth' });
+  }
 
-	const observer = lozad(); // lazy loads elements with default selector as ".lozad"
-	observer.observe();
+  function initSmoothScroll() {
+    document.addEventListener('click', (event) => {
+      const anchor = event.target instanceof Element ? event.target.closest('a') : null;
+      if (!anchor) return;
 
-	/* ========================================================================= */
-	/*	Magnific popup (optional)
-	/* =========================================================================  */
+      const classList = anchor.classList;
+      const isSmooth =
+        anchor.closest('nav') ||
+        classList.contains('page-scroll') ||
+        classList.contains('js-smooth-scroll');
 
-	if ($.fn.magnificPopup && $('.image-popup').length) {
-		$('.image-popup').magnificPopup({
-			type: 'image',
-			removalDelay: 160, //delay removal by X to allow out-animation
-			callbacks: {
-				beforeOpen: function () {
-					// just a hack that adds mfp-anim class to markup
-					this.st.image.markup = this.st.image.markup.replace('mfp-figure', 'mfp-figure mfp-with-anim');
-					this.st.mainClass = this.st.el.attr('data-effect');
-				}
-			},
-			closeOnContentClick: true,
-			midClick: true,
-			fixedContentPos: false,
-			fixedBgPos: true
-		});
-	}
+      if (!isSmooth) return;
 
-	/* ========================================================================= */
-	/*	Portfolio Filtering Hook (optional)
-	/* =========================================================================  */
+      const href = anchor.getAttribute('href') || '';
+      if (!href.startsWith('#')) return;
 
-	var containerEl = document.querySelector('.shuffle-wrapper');
-	if (containerEl && window.Shuffle) {
-		var Shuffle = window.Shuffle;
-		var myShuffle = new Shuffle(document.querySelector('.shuffle-wrapper'), {
-			itemSelector: '.shuffle-item',
-			buffer: 1
-		});
+      const target = document.getElementById(href.slice(1)) || document.querySelector(`[name="${href.slice(1)}"]`);
+      if (!target) return;
 
-		jQuery('input[name="shuffle-filter"]').on('change', function (evt) {
-			var input = evt.currentTarget;
-			if (input.checked) {
-				myShuffle.filter(input.value);
-			}
-		});
-	}
+      event.preventDefault();
+      scrollToTarget(target);
+    });
+  }
 
-	/* ========================================================================= */
-	/*	Testimonial Carousel (optional)
-	/* =========================================================================  */
+  function setCollapseExpanded(button, expanded) {
+    button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  }
 
-	if ($.fn.slick && $("#testimonials").length) {
-		$("#testimonials").slick({
-			infinite: true,
-			arrows: false,
-			autoplay: true,
-			autoplaySpeed: 4000
-		});
-	}
+  function initNavCollapse() {
+    const toggle = document.querySelector('[data-nav-toggle]');
+    const menu = document.querySelector('[data-nav-menu]');
+    if (!toggle || !menu) return;
 
-	/* ========================================================================= */
-	/*	animation scroll js
-	/* ========================================================================= */
+    toggle.addEventListener('click', () => {
+      const isOpen = menu.classList.contains('show');
+      if (isOpen) {
+        menu.classList.remove('show');
+        setCollapseExpanded(toggle, false);
+      } else {
+        menu.classList.add('show');
+        setCollapseExpanded(toggle, true);
+      }
+    });
 
-	function myFunction(x) {
-		if (x.matches) {
-			var topOf = 50
-		} else {
-			var topOf = 350
-		}
-	}
+    menu.addEventListener('click', (event) => {
+      const anchor = event.target instanceof Element ? event.target.closest('a') : null;
+      if (!anchor) return;
+      if (anchor.hasAttribute('data-nav-dropdown-toggle')) return;
 
-	var html_body = $('html, body');
-	$('nav a, .page-scroll, .js-smooth-scroll').on('click', function () { //use page-scroll class in any HTML tag for scrolling
-		if (location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '') && location.hostname === this.hostname) {
-			var target = $(this.hash);
-			target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
-			if (target.length) {
-				html_body.animate({
-					scrollTop: target.offset().top - 50
-				}, 1500, 'easeInOutExpo');
-				return false;
-			}
-		}
-	});
+      if (menu.classList.contains('show')) {
+        menu.classList.remove('show');
+        setCollapseExpanded(toggle, false);
+      }
+    });
+  }
 
-	// easeInOutExpo Declaration
-	jQuery.extend(jQuery.easing, {
-		easeInOutExpo: function (x, t, b, c, d) {
-			if (t === 0) {
-				return b;
-			}
-			if (t === d) {
-				return b + c;
-			}
-			if ((t /= d / 2) < 1) {
-				return c / 2 * Math.pow(2, 10 * (t - 1)) + b;
-			}
-			return c / 2 * (-Math.pow(2, -10 * --t) + 2) + b;
-		}
-	});
+  function closeAllNavDropdowns(navRoot) {
+    const openDropdowns = navRoot.querySelectorAll('.dropdown.show');
+    openDropdowns.forEach((dropdown) => {
+      dropdown.classList.remove('show');
+      const menu = dropdown.querySelector('.dropdown-menu');
+      if (menu) menu.classList.remove('show');
+      const toggle = dropdown.querySelector('[data-nav-dropdown-toggle]');
+      if (toggle) toggle.setAttribute('aria-expanded', 'false');
+    });
+  }
 
-	/* ========================================================================= */
-	/*	counter up
-	/* ========================================================================= */
-	function counter() {
-		var oTop;
-		if ($('.count').length !== 0) {
-			oTop = $('.count').offset().top - window.innerHeight;
-		}
-		if ($(window).scrollTop() > oTop) {
-			$('.count').each(function () {
-				var $this = $(this),
-					countTo = $this.attr('data-count');
-				$({
-					countNum: $this.text()
-				}).animate({
-					countNum: countTo
-				}, {
-					duration: 1000,
-					easing: 'swing',
-					step: function () {
-						$this.text(Math.floor(this.countNum));
-					},
-					complete: function () {
-						$this.text(this.countNum);
-					}
-				});
-			});
-		}
-	}
-	$(window).on('scroll', function () {
-		counter();
-	});
+  function initNavDropdowns() {
+    const navRoot = document.querySelector('.navigation');
+    if (!navRoot) return;
 
-});
+    navRoot.addEventListener('click', (event) => {
+      const toggle = event.target instanceof Element ? event.target.closest('[data-nav-dropdown-toggle]') : null;
+      if (!toggle) return;
+
+      event.preventDefault();
+      const dropdown = toggle.closest('.dropdown');
+      if (!dropdown) return;
+
+      const menu = dropdown.querySelector('.dropdown-menu');
+      const isOpen = dropdown.classList.contains('show');
+
+      closeAllNavDropdowns(navRoot);
+
+      if (!isOpen) {
+        dropdown.classList.add('show');
+        if (menu) menu.classList.add('show');
+        toggle.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (navRoot.contains(target)) return;
+      closeAllNavDropdowns(navRoot);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape') return;
+      closeAllNavDropdowns(navRoot);
+    });
+  }
+
+  function initCounters() {
+    const counters = Array.from(document.querySelectorAll('.count[data-count]'));
+    if (counters.length === 0) return;
+
+    let hasRun = false;
+    const run = () => {
+      if (hasRun) return;
+      hasRun = true;
+
+      counters.forEach((counter) => {
+        const rawTarget = counter.getAttribute('data-count') || '0';
+        const targetValue = Number.parseInt(rawTarget, 10);
+        if (!Number.isFinite(targetValue)) return;
+
+        const durationMs = 1000;
+        const start = performance.now();
+        const startValue = 0;
+
+        const tick = (now) => {
+          const progress = Math.min(1, (now - start) / durationMs);
+          const current = Math.floor(startValue + (targetValue - startValue) * progress);
+          counter.textContent = String(current);
+          if (progress < 1) requestAnimationFrame(tick);
+        };
+
+        requestAnimationFrame(tick);
+      });
+    };
+
+    const first = counters[0];
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          run();
+          observer.disconnect();
+        }
+      },
+      { root: null, rootMargin: '0px 0px -20% 0px', threshold: 0.01 },
+    );
+
+    observer.observe(first);
+  }
+
+  window.addEventListener('load', () => {
+    hidePreloader();
+    initLazyLoad();
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initSmoothScroll();
+    initNavCollapse();
+    initNavDropdowns();
+    initCounters();
+  });
+})();
 

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -71,10 +71,6 @@ link = "plugins/themify-icons/themify-icons.css"
 
 # js plugins
 [[params.plugins.js]]
-link = "plugins/jquery/jquery.min.js"
-[[params.plugins.js]]
-link = "plugins/bootstrap/bootstrap.min.js"
-[[params.plugins.js]]
 link = "plugins/lazy-load/lozad.min.js"
 
 ############################# Default Parameters ##########################

--- a/layouts/_default/article.html
+++ b/layouts/_default/article.html
@@ -10,10 +10,10 @@
         "Class" (cond $aboveFold "img-fluid img-blog" "img-fluid lozad img-blog")
         "Loading" (cond $aboveFold "eager" "lazy")
         "FetchPriority" (cond $isLcp "high" "")
-        "DisplayXL" "800x"
-        "DisplayLG" "640x"
-        "DisplayMD" "480x"
-        "DisplaySM" "360x"
+        "DisplayXL" "800x q70"
+        "DisplayLG" "640x q70"
+        "DisplayMD" "480x q70"
+        "DisplaySM" "360x q70"
         "Context" .
       ) }}
       </a>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ with site.LanguageCode }}{{ . }}{{ else }}en-us{{ end }}">
 {{ partial "head.html" . }}
 
-<body id="body" data-spy="scroll" data-target=".navbar" data-offset="55">
+<body id="body">
   {{ partial "navigation.html" . }}
   
   <div id="content">

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -271,8 +271,8 @@
               lazy
             {{ end }} {{ $class }} img"
             alt="{{ .Alt }}"
-            width="{{ $image.Width }}"
-            height="{{ $image.Height }}" />
+            width="{{ $imageFallback.Width }}"
+            height="{{ $imageFallback.Height }}" />
         </picture>
       {{ end }}
       <!-- end image processing -->

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,0 +1,74 @@
+<section class="sticky-top navigation">
+  <div class="container">
+    <nav class="navbar navbar-expand-lg navbar-dark">
+      <a class="navbar-brand p-0" href="{{ .Site.BaseURL | relLangURL }}">
+        {{ if site.Params.logo }}
+        {{ partial "image.html" (dict "Src" site.Params.logo "Alt" .Site.Title "Class" "lozad") }}
+        {{ else }} {{ site.Title }} {{ end }}
+      </a>
+
+      <button
+        class="navbar-toggler rounded-0"
+        type="button"
+        aria-controls="navigation"
+        aria-expanded="false"
+        data-nav-toggle="navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navigation" data-nav-menu>
+        <ul class="navbar-nav ml-auto">
+          <!-- menu active -->
+          {{ $currentPage := . }} {{ range site.Menus.main }} {{ $menuURL :=
+          .URL | absLangURL }} {{ $pageURL:= $currentPage.Permalink | absLangURL
+          }} {{ $active := eq $menuURL $pageURL }} {{ if .HasChildren }}
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              role="button"
+              aria-haspopup="true"
+              aria-expanded="false"
+              data-nav-dropdown-toggle
+            >
+              {{ .Name }}
+            </a>
+            <div class="dropdown-menu" data-nav-dropdown-menu>
+              {{ range .Children }} {{ $childURL := .URL | absLangURL }} {{
+              $active := eq $childURL $pageURL }}
+              <a
+                class="dropdown-item"
+                {{if
+                findRE
+                `^http`
+                .URL}}target="_blank"
+                rel="noopener"
+                {{end}}
+                href="{{if findRE `^#` .URL}}{{if not $.IsHome}}{{site.BaseURL | relLangURL}}{{end}}{{.URL}}{{else}}{{.URL | relLangURL}}{{end}}"
+                >{{ .Name }}</a
+              >
+              {{ end }}
+            </div>
+          </li>
+          {{ else }}
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              {{if
+              findRE
+              `^http`
+              .URL}}target="_blank"
+              rel="noopener"
+              {{end}}
+              href="{{if findRE `^#` .URL}}{{if not $.IsHome}}{{site.BaseURL | relLangURL}}{{end}}{{.URL}}{{else}}{{.URL | relLangURL}}{{end}}"
+              >{{.Name}}</a
+            >
+          </li>
+          {{ end }} {{ end }}
+        </ul>
+      </div>
+    </nav>
+  </div>
+</section>
+

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -32,18 +32,20 @@
 	This site uses cookies. By continuing to use this website, you agree to their use. <span id="js-cookie-button" class="btn btn-transparent">I Accept</span>
 </div>
 <script>
-	(function ($) {
+	(function () {
 		const cookieBox = document.getElementById('js-cookie-box');
 		const cookieButton = document.getElementById('js-cookie-button');
+		if (!cookieBox || !cookieButton || !window.Cookies) return;
+
 		if (!Cookies.get('cookie-box')) {
 			cookieBox.classList.remove('cookie-box-hide');
-			cookieButton.onclick = function () {
+			cookieButton.addEventListener('click', function () {
 				Cookies.set('cookie-box', true, {
 					expires: {{ site.Params.cookies.expire_days }}
 				});
 				cookieBox.classList.add('cookie-box-hide');
-			};
+			});
 		}
-	})(jQuery);
+	})();
 </script>
 {{ end }}


### PR DESCRIPTION
Closes #51
Closes #52

Summary
- Improves blog card image markup + compression by switching `<picture>` `img` width/height to the processed derivative dimensions, and by applying explicit WebP quality for card breakpoints.
- Removes jQuery + Bootstrap JS from the vendor bundle and replaces required behavior with small vanilla JS (nav collapse + dropdown, smooth scroll, counters, lozad init).
- Updates cookie banner script to avoid jQuery.

Notes
- #55 was closed separately as `not planned` + `wontfix` since it is `draft: true` and not production-impacting.

Tested
- `npm run test:seo`