### PR TITLE
fix: bust cached fingerprinted assets

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -17,9 +17,10 @@
 
 {{ if and $ahrefsEnabled $ahrefsDataKey (eq hugo.Environment "production") }}
 {{ $ahrefsScript := resources.Get "vendor/ahrefs/analytics.js" | fingerprint "sha384" }}
+{{ $ahrefsScriptURL := printf "%s?v=%s" $ahrefsScript.Permalink ($ahrefsScript.Data.Integrity | urlquery) }}
 <script
   async
-  src="{{ $ahrefsScript.Permalink }}"
+  src="{{ $ahrefsScriptURL }}"
   integrity="{{ $ahrefsScript.Data.Integrity }}"
   data-key="{{ $ahrefsDataKey }}"
 ></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -150,10 +150,11 @@
 	{{ partial "critical-css.html" . }}
 	{{ if gt (len $deferredCssParts) 0 }}
 		{{ $siteCss := $deferredCssParts | resources.Concat "css/site.css" | minify | fingerprint "sha384" }}
-		<link rel="preload" href="{{ $siteCss.Permalink }}" as="style" integrity="{{ $siteCss.Data.Integrity }}">
-		<link rel="stylesheet" href="{{ $siteCss.Permalink }}" integrity="{{ $siteCss.Data.Integrity }}" onload="this.onload=null;this.rel='stylesheet'">
+		{{ $siteCssURL := printf "%s?v=%s" $siteCss.Permalink ($siteCss.Data.Integrity | urlquery) }}
+		<link rel="preload" href="{{ $siteCssURL }}" as="style" integrity="{{ $siteCss.Data.Integrity }}">
+		<link rel="stylesheet" href="{{ $siteCssURL }}" integrity="{{ $siteCss.Data.Integrity }}" onload="this.onload=null;this.rel='stylesheet'">
 		<noscript>
-			<link rel="stylesheet" href="{{ $siteCss.Permalink }}" integrity="{{ $siteCss.Data.Integrity }}">
+			<link rel="stylesheet" href="{{ $siteCssURL }}" integrity="{{ $siteCss.Data.Integrity }}">
 		</noscript>
 	{{ end }}
 

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -18,12 +18,14 @@
 {{ end }}
 {{ if gt (len $vendorJsParts) 0 }}
 	{{ $vendorJs := $vendorJsParts | resources.Concat "js/vendor.js" | minify | fingerprint "sha384" }}
-	<script src="{{ $vendorJs.Permalink }}" integrity="{{ $vendorJs.Data.Integrity }}" defer></script>
+	{{ $vendorJsURL := printf "%s?v=%s" $vendorJs.Permalink ($vendorJs.Data.Integrity | urlquery) }}
+	<script src="{{ $vendorJsURL }}" integrity="{{ $vendorJs.Data.Integrity }}" defer></script>
 {{ end }}
 
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify | fingerprint "sha384"}}
-<script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity }}" defer></script>
+{{ $scriptURL := printf "%s?v=%s" $script.Permalink ($script.Data.Integrity | urlquery) }}
+<script src="{{ $scriptURL }}" integrity="{{ $script.Data.Integrity }}" defer></script>
 
 <!-- cookie -->
 {{ if site.Params.cookies.enable }}

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -155,11 +155,38 @@ describe('SEO build assertions', () => {
         preloadStyles.length === 1,
         `[${page.relativePath}] must preload exactly one deferred stylesheet bundle.`,
       );
+      const preloadHref = preloadStyles.first().attr('href')?.trim() ?? '';
+      assert(
+        preloadHref.includes('?v='),
+        `[${page.relativePath}] deferred stylesheet preload must include a stable cache-busting query string.`,
+      );
 
       const deferredStylesheet = $('link[rel="stylesheet"][href*="/css/site."]');
       assert(
         deferredStylesheet.length === 1,
         `[${page.relativePath}] must load the combined site stylesheet bundle.`,
+      );
+      const deferredHref = deferredStylesheet.attr('href')?.trim() ?? '';
+      assert(
+        deferredHref.includes('?v='),
+        `[${page.relativePath}] combined site stylesheet must include a stable cache-busting query string.`,
+      );
+      assert(
+        preloadHref === deferredHref,
+        `[${page.relativePath}] deferred stylesheet preload and stylesheet href must match exactly.`,
+      );
+
+      const noScriptDeferredMatch = html.match(
+        /<noscript>\s*<link rel=stylesheet href="([^"]*\/css\/site\.[^"]*)"/i,
+      );
+      assert(
+        noScriptDeferredMatch,
+        `[${page.relativePath}] must include a noscript fallback for the combined site stylesheet bundle.`,
+      );
+      const noScriptDeferredHref = noScriptDeferredMatch[1]?.trim() ?? '';
+      assert(
+        noScriptDeferredHref === deferredHref,
+        `[${page.relativePath}] noscript stylesheet href must match the deferred stylesheet href exactly.`,
       );
 
       assert(
@@ -186,6 +213,10 @@ describe('SEO build assertions', () => {
         assert(
           ahrefsSrc && !ahrefsSrc.includes('analytics.ahrefs.com'),
           `[${page.relativePath}] Ahrefs analytics must be served from the local site, not analytics.ahrefs.com. Actual src: "${ahrefsSrc}".`,
+        );
+        assert(
+          ahrefsSrc.includes('?v='),
+          `[${page.relativePath}] Ahrefs analytics must include a stable cache-busting query string.`,
         );
 
         assertResolvableAssetUrl(
@@ -278,6 +309,17 @@ describe('SEO build assertions', () => {
         assertNoLegacySegments(
           href.pathname,
           `[${page.relativePath}] found internal link to a retired language URL: "${href.href}".`,
+        );
+      }
+
+      const fingerprintedScripts = $('script[src*="/js/vendor."], script[src*="/js/script."]')
+        .toArray()
+        .map((scriptElement) => $(scriptElement).attr('src')?.trim() ?? '')
+        .filter(Boolean);
+      for (const scriptSrc of fingerprintedScripts) {
+        assert(
+          scriptSrc.includes('?v='),
+          `[${page.relativePath}] fingerprinted script assets must include a stable cache-busting query string. Actual src: "${scriptSrc}".`,
         );
       }
 


### PR DESCRIPTION
## Summary
- append a stable `?v=` query string to fingerprinted CSS and JS asset URLs based on the integrity hash
- keep the deferred stylesheet preload, stylesheet tag, and noscript fallback aligned on the exact same URL
- extend the SEO build assertions so fingerprinted CSS/JS URLs keep the cache-busting query in generated HTML

## Why
Production was serving HTML that referenced the new fingerprinted `site.min...css`, but the exact URL had a cached `404` while the same asset responded `200` when requested with a query string. Because `/css/*` is served with `Cache-Control: public, max-age=31536000, immutable`, that bad response could stick around.

This change forces a fresh URL at the edge without giving up the existing fingerprinted filenames.

## Verification
- `npm run build`
- `npm run test:seo:assert`