### PR TITLE
Issue #70: Branded redirect bridge page for Umami tracking

### DIFF
--- a/assets/css/custom/25-redirect.css
+++ b/assets/css/custom/25-redirect.css
@@ -1,0 +1,120 @@
+/** Section: Redirect Bridge **/
+.redirect-page {
+  background: var(--surface-base);
+  padding: 7rem 0 6rem;
+}
+
+.redirect-shell {
+  color: var(--text-base);
+  font-family: "EB Garamond", serif;
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+.redirect-hero {
+  border-bottom: 1px solid rgb(17 17 17 / 12%);
+  margin-bottom: 3rem;
+  padding-bottom: 2.25rem;
+  text-align: center;
+}
+
+.redirect-eyebrow {
+  color: var(--text-base);
+  font-family: Inter, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  margin: 0 0 1rem;
+  opacity: 0.65;
+  text-transform: uppercase;
+}
+
+.redirect-title {
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  margin: 0;
+}
+
+.redirect-subtitle {
+  color: rgb(17 17 17 / 78%);
+  font-family: "EB Garamond", serif;
+  font-size: clamp(1.15rem, 2vw, 1.35rem);
+  line-height: 1.6;
+  margin: 1.25rem auto 0;
+  max-width: 38rem;
+}
+
+.redirect-card {
+  background: var(--surface-card);
+  border: 1px solid rgb(17 17 17 / 12%);
+  padding: 1.75rem 1.85rem;
+}
+
+.redirect-row {
+  align-items: flex-start;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 44px minmax(0, 1fr);
+}
+
+.redirect-spinner {
+  border: 2px solid rgb(17 17 17 / 12%);
+  border-left-color: var(--text-base);
+  border-radius: 50%;
+  height: 44px;
+  width: 44px;
+  animation: redirect-spin 0.9s linear infinite;
+}
+
+@keyframes redirect-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.redirect-message {
+  font-family: "EB Garamond", serif;
+  font-size: 1.35rem;
+  line-height: 1.2;
+  margin: 0 0 0.5rem;
+}
+
+.redirect-fallback {
+  color: rgb(17 17 17 / 72%);
+  font-family: Inter, sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.redirect-fallback a {
+  color: var(--text-base);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.redirect-fallback a:hover,
+.redirect-fallback a:focus {
+  color: var(--brand-primary-hover);
+}
+
+@media (width <= 768px) {
+  .redirect-page {
+    padding: 6rem 0 4.5rem;
+  }
+
+  .redirect-card {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .redirect-row {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .redirect-spinner {
+    height: 38px;
+    width: 38px;
+  }
+}

--- a/content/english/redirect/index.md
+++ b/content/english/redirect/index.md
@@ -1,0 +1,5 @@
++++
+title = "Redirecting..."
+type = "redirect"
+url = "/redirect/"
++++

--- a/data/en/redirects.yml
+++ b/data/en/redirects.yml
@@ -1,0 +1,11 @@
+# Redirect destinations for /redirect/<slug>.
+#
+# Format:
+# - slug: "adplist-coaching"
+#   label: "ADPList"
+#   url: "https://adplist.org/..."
+#
+# Keep this list small and explicit. JS derives the allowed host list from `url` values.
+- slug: "adplist-coaching"
+  label: "ADPList"
+  url: "https://adplist.org/mentors/christian-guzman"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -28,7 +28,7 @@
             <p class="redirect-message" id="redirect-message">Redirecting...</p>
             <p class="redirect-fallback">
               If you are not redirected within 5 seconds,
-              <a id="redirect-link" href="/engineering-leadership-coaching/" rel="noopener">click here</a>.
+              <a id="redirect-link" href="/engineering-leadership-coaching/" target="_blank" rel="noopener noreferrer">click here</a>.
             </p>
           </div>
         </div>

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -61,7 +61,17 @@
             const node = document.getElementById(id);
             if (!node) return null;
             try {
-              return JSON.parse(node.textContent || "null");
+              let parsed = JSON.parse(node.textContent || "null");
+              // Hugo's minify pipeline can end up serializing data into a JSON string.
+              // Accept both: array/object OR JSON-string-wrapping-the-real-payload.
+              if (typeof parsed === "string") {
+                try {
+                  parsed = JSON.parse(parsed);
+                } catch {
+                  // ignore
+                }
+              }
+              return parsed;
             } catch {
               return null;
             }

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,197 @@
+{{ define "main" }}
+
+<section class="section" id="regular-404">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center">
+        <h1>404</h1>
+        <h2>Page Not Found</h2>
+        <a class="btn btn-main" href="{{ site.BaseURL | relLangURL }}">Back to home</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section redirect-page" id="redirect-404" style="display: none;" aria-label="Redirect bridge page">
+  <div class="container">
+    <div class="redirect-shell">
+      <header class="redirect-hero">
+        <p class="redirect-eyebrow">Redirect</p>
+        <h1 class="redirect-title">You are being redirected<span class="redirect-ellipsis" aria-hidden="true">...</span></h1>
+        <p class="redirect-subtitle" id="redirect-subtitle">Preparing destination.</p>
+      </header>
+
+      <div class="redirect-card" role="status" aria-live="polite">
+        <div class="redirect-row">
+          <span class="redirect-spinner" aria-hidden="true"></span>
+          <div class="redirect-copy">
+            <p class="redirect-message" id="redirect-message">Redirecting...</p>
+            <p class="redirect-fallback">
+              If you are not redirected within 5 seconds,
+              <a id="redirect-link" href="/engineering-leadership-coaching/" rel="noopener">click here</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {{ $redirects := site.Data.en.redirects | default (slice) }}
+      <script type="application/json" id="redirect-map">{{ $redirects | jsonify }}</script>
+      <script>
+        (function () {
+          const pathname = window.location.pathname || "";
+          const isRedirectPath = pathname === "/redirect" || pathname.startsWith("/redirect/");
+          if (!isRedirectPath) {
+            return;
+          }
+
+          const regular404 = document.getElementById("regular-404");
+          const redirect404 = document.getElementById("redirect-404");
+          if (regular404) regular404.style.display = "none";
+          if (redirect404) redirect404.style.display = "";
+
+          const FAILURE_URL = "/engineering-leadership-coaching/";
+          const REDIRECT_DELAY_MS = 1800;
+          const PASS_THROUGH_KEYS = new Set(["gclid", "fbclid", "msclkid"]);
+
+          function redirectFailure() {
+            window.location.assign(FAILURE_URL);
+          }
+
+          function readJsonScript(id) {
+            const node = document.getElementById(id);
+            if (!node) return null;
+            try {
+              return JSON.parse(node.textContent || "null");
+            } catch {
+              return null;
+            }
+          }
+
+          function extractSlug(pathname) {
+            const parts = pathname.split("/").filter(Boolean);
+            const redirectIndex = parts.indexOf("redirect");
+            if (redirectIndex < 0) return "";
+            return parts[redirectIndex + 1] || "";
+          }
+
+          function isAllowedHost(url, allowedHosts) {
+            try {
+              const parsed = new URL(url);
+              if (parsed.protocol !== "https:") return false;
+              return allowedHosts.has(parsed.host);
+            } catch {
+              return false;
+            }
+          }
+
+          function buildAllowedHosts(entries) {
+            const hosts = new Set();
+            for (const entry of entries) {
+              if (!entry || typeof entry.url !== "string") continue;
+              try {
+                const parsed = new URL(entry.url);
+                if (parsed.protocol === "https:" && parsed.host) hosts.add(parsed.host);
+              } catch {
+                // ignore invalid URLs in data
+              }
+            }
+            return hosts;
+          }
+
+          function readLabel(searchParams, entry, destinationUrl) {
+            const override = (searchParams.get("label") || "").trim();
+            if (override) return override;
+            if (entry && typeof entry.label === "string" && entry.label.trim()) return entry.label.trim();
+            const slug = (searchParams.get("slug") || "").trim();
+            if (slug) return slug;
+            try {
+              return new URL(destinationUrl).host;
+            } catch {
+              return "destination";
+            }
+          }
+
+          function copyAttributionParams(fromParams, toUrl) {
+            for (const [key, value] of fromParams.entries()) {
+              if (!key) continue;
+              if (key === "to" || key === "label" || key === "delay" || key === "slug") continue;
+              if (key.startsWith("utm_") || PASS_THROUGH_KEYS.has(key)) {
+                toUrl.searchParams.set(key, value);
+              }
+            }
+          }
+
+          const subtitle = document.getElementById("redirect-subtitle");
+          const message = document.getElementById("redirect-message");
+          const link = document.getElementById("redirect-link");
+
+          const currentUrl = new URL(window.location.href);
+          const slugFromPath = extractSlug(window.location.pathname);
+          const slugFromQuery = (currentUrl.searchParams.get("slug") || "").trim();
+          const slug = slugFromPath || slugFromQuery;
+          if (!slug) {
+            redirectFailure();
+            return;
+          }
+
+          const entries = readJsonScript("redirect-map");
+          const redirectEntries = Array.isArray(entries) ? entries : [];
+          const allowedHosts = buildAllowedHosts(redirectEntries);
+
+          const entry = redirectEntries.find((candidate) => candidate && candidate.slug === slug) || null;
+          const requestedTo = (currentUrl.searchParams.get("to") || "").trim();
+
+          let destination = "";
+          if (entry && typeof entry.url === "string" && entry.url.trim()) {
+            destination = entry.url.trim();
+          }
+          if (requestedTo) {
+            if (isAllowedHost(requestedTo, allowedHosts)) {
+              destination = requestedTo;
+            } else {
+              redirectFailure();
+              return;
+            }
+          }
+          let fallbackToCoaching = false;
+          if (!destination) {
+            fallbackToCoaching = true;
+            destination = FAILURE_URL;
+          }
+
+          let destinationUrl;
+          try {
+            destinationUrl = new URL(destination, window.location.origin);
+          } catch {
+            redirectFailure();
+            return;
+          }
+
+          if (!fallbackToCoaching) {
+            copyAttributionParams(currentUrl.searchParams, destinationUrl);
+          }
+
+          const labelParams = new URLSearchParams(currentUrl.searchParams);
+          if (!labelParams.has("slug") && slug) {
+            labelParams.set("slug", slug);
+          }
+          const label = readLabel(labelParams, entry, destinationUrl.href);
+          if (fallbackToCoaching) {
+            if (subtitle) subtitle.textContent = `Unknown redirect: ${label}`;
+            if (message) message.textContent = `Redirecting you to coaching...`;
+          } else {
+            if (subtitle) subtitle.textContent = `Destination: ${label}`;
+            if (message) message.textContent = `You are being redirected to ${label}...`;
+          }
+          if (link) link.href = destinationUrl.href;
+
+          window.setTimeout(() => {
+            window.location.assign(destinationUrl.href);
+          }, REDIRECT_DELAY_MS);
+        })();
+      </script>
+    </div>
+  </div>
+</section>
+
+{{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -126,10 +126,13 @@
           const link = document.getElementById("redirect-link");
 
           const currentUrl = new URL(window.location.href);
-          const slugFromPath = extractSlug(window.location.pathname);
-          const slugFromQuery = (currentUrl.searchParams.get("slug") || "").trim();
-          const slug = slugFromPath || slugFromQuery;
-          if (!slug) {
+          const debug = (currentUrl.searchParams.get("debug") || "").trim() === "1";
+
+          const slugFromPathRaw = extractSlug(window.location.pathname);
+          const slugFromQueryRaw = (currentUrl.searchParams.get("slug") || "").trim();
+          const slugRaw = (slugFromPathRaw || slugFromQueryRaw || "").trim();
+          const slugKey = slugRaw.toLowerCase();
+          if (!slugKey) {
             redirectFailure();
             return;
           }
@@ -138,7 +141,11 @@
           const redirectEntries = Array.isArray(entries) ? entries : [];
           const allowedHosts = buildAllowedHosts(redirectEntries);
 
-          const entry = redirectEntries.find((candidate) => candidate && candidate.slug === slug) || null;
+          const entry =
+            redirectEntries.find((candidate) => {
+              if (!candidate || typeof candidate.slug !== "string") return false;
+              return candidate.slug.trim().toLowerCase() === slugKey;
+            }) || null;
           const requestedTo = (currentUrl.searchParams.get("to") || "").trim();
 
           let destination = "";
@@ -172,8 +179,8 @@
           }
 
           const labelParams = new URLSearchParams(currentUrl.searchParams);
-          if (!labelParams.has("slug") && slug) {
-            labelParams.set("slug", slug);
+          if (!labelParams.has("slug") && slugRaw) {
+            labelParams.set("slug", slugRaw);
           }
           const label = readLabel(labelParams, entry, destinationUrl.href);
           if (fallbackToCoaching) {
@@ -184,6 +191,28 @@
             if (message) message.textContent = `You are being redirected to ${label}...`;
           }
           if (link) link.href = destinationUrl.href;
+
+          if (debug) {
+            const details = {
+              slugRaw,
+              slugKey,
+              matched: Boolean(entry),
+              entry,
+              destination: destinationUrl.href,
+              requestedTo: requestedTo || null,
+              allowedHosts: Array.from(allowedHosts.values()),
+              fallbackToCoaching,
+              passThrough: Object.fromEntries(
+                Array.from(currentUrl.searchParams.entries()).filter(
+                  ([k]) => k.startsWith("utm_") || PASS_THROUGH_KEYS.has(k),
+                ),
+              ),
+            };
+            // eslint-disable-next-line no-console
+            console.info("[redirect-bridge debug]", details);
+            if (message) message.textContent = `Debug mode: check console.`;
+            return;
+          }
 
           window.setTimeout(() => {
             window.location.assign(destinationUrl.href);

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -67,6 +67,9 @@
 	<meta name="description" content="{{ $description }}">
 	<meta name="author" content="{{ $author }}">
 	<link rel="canonical" href="{{ .Permalink }}">
+	{{ if eq .Type "redirect" }}
+	<meta name="robots" content="noindex,nofollow">
+	{{ end }}
 
 	<meta property="og:title" content="{{ $title }}">
 	<meta property="og:description" content="{{ $description }}">
@@ -128,6 +131,7 @@
 		"css/custom/22-article-author-related.css"
 		"css/custom/23-article-effects.css"
 		"css/custom/24-strategy-session.css"
+		"css/custom/25-redirect.css"
 		"css/custom/30-funfacts.css"
 		"css/custom/40-footer.css"
 	}}

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -16,7 +16,7 @@
             <p class="redirect-message" id="redirect-message">Redirecting...</p>
             <p class="redirect-fallback">
               If you are not redirected within 5 seconds,
-              <a id="redirect-link" href="/engineering-leadership-coaching/" rel="noopener">click here</a>.
+              <a id="redirect-link" href="/engineering-leadership-coaching/" target="_blank" rel="noopener noreferrer">click here</a>.
             </p>
           </div>
         </div>

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -98,15 +98,18 @@
             }
           }
 
+          const currentUrl = new URL(window.location.href);
+          const debug = (currentUrl.searchParams.get("debug") || "").trim() === "1";
+
           const subtitle = document.getElementById("redirect-subtitle");
           const message = document.getElementById("redirect-message");
           const link = document.getElementById("redirect-link");
 
-          const currentUrl = new URL(window.location.href);
-          const slugFromPath = extractSlug(window.location.pathname);
-          const slugFromQuery = (currentUrl.searchParams.get("slug") || "").trim();
-          const slug = slugFromPath || slugFromQuery;
-          if (!slug) {
+          const slugFromPathRaw = extractSlug(window.location.pathname);
+          const slugFromQueryRaw = (currentUrl.searchParams.get("slug") || "").trim();
+          const slugRaw = (slugFromPathRaw || slugFromQueryRaw || "").trim();
+          const slugKey = slugRaw.toLowerCase();
+          if (!slugKey) {
             redirectFailure();
             return;
           }
@@ -115,7 +118,11 @@
           const redirectEntries = Array.isArray(entries) ? entries : [];
           const allowedHosts = buildAllowedHosts(redirectEntries);
 
-          const entry = redirectEntries.find((candidate) => candidate && candidate.slug === slug) || null;
+          const entry =
+            redirectEntries.find((candidate) => {
+              if (!candidate || typeof candidate.slug !== "string") return false;
+              return candidate.slug.trim().toLowerCase() === slugKey;
+            }) || null;
           const requestedTo = (currentUrl.searchParams.get("to") || "").trim();
 
           let destination = "";
@@ -149,8 +156,8 @@
           }
 
           const labelParams = new URLSearchParams(currentUrl.searchParams);
-          if (!labelParams.has("slug") && slug) {
-            labelParams.set("slug", slug);
+          if (!labelParams.has("slug") && slugRaw) {
+            labelParams.set("slug", slugRaw);
           }
           const label = readLabel(labelParams, entry, destinationUrl.href);
           if (fallbackToCoaching) {
@@ -162,6 +169,28 @@
             if (message) message.textContent = `You are being redirected to ${label}...`;
           }
           if (link) link.href = destinationUrl.href;
+
+          if (debug) {
+            const details = {
+              slugRaw,
+              slugKey,
+              matched: Boolean(entry),
+              entry,
+              destination: destinationUrl.href,
+              requestedTo: requestedTo || null,
+              allowedHosts: Array.from(allowedHosts.values()),
+              fallbackToCoaching,
+              passThrough: Object.fromEntries(
+                Array.from(currentUrl.searchParams.entries()).filter(
+                  ([k]) => k.startsWith("utm_") || PASS_THROUGH_KEYS.has(k),
+                ),
+              ),
+            };
+            // eslint-disable-next-line no-console
+            console.info("[redirect-bridge debug]", details);
+            if (message) message.textContent = `Debug mode: check console.`;
+            return;
+          }
 
           window.setTimeout(() => {
             window.location.assign(destinationUrl.href);

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,175 @@
+{{ define "main" }}
+
+<section class="section redirect-page" aria-label="Redirect bridge page">
+  <div class="container">
+    <div class="redirect-shell">
+      <header class="redirect-hero">
+        <p class="redirect-eyebrow">Redirect</p>
+        <h1 class="redirect-title">You are being redirected<span class="redirect-ellipsis" aria-hidden="true">...</span></h1>
+        <p class="redirect-subtitle" id="redirect-subtitle">Preparing destination.</p>
+      </header>
+
+      <div class="redirect-card" role="status" aria-live="polite">
+        <div class="redirect-row">
+          <span class="redirect-spinner" aria-hidden="true"></span>
+          <div class="redirect-copy">
+            <p class="redirect-message" id="redirect-message">Redirecting...</p>
+            <p class="redirect-fallback">
+              If you are not redirected within 5 seconds,
+              <a id="redirect-link" href="/engineering-leadership-coaching/" rel="noopener">click here</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {{ $redirects := site.Data.en.redirects | default (slice) }}
+      <script type="application/json" id="redirect-map">{{ $redirects | jsonify }}</script>
+      <script>
+        (function () {
+          const FAILURE_URL = "/engineering-leadership-coaching/";
+          const REDIRECT_DELAY_MS = 1800;
+          const PASS_THROUGH_KEYS = new Set(["gclid", "fbclid", "msclkid"]);
+
+          function redirectFailure() {
+            window.location.assign(FAILURE_URL);
+          }
+
+          function readJsonScript(id) {
+            const node = document.getElementById(id);
+            if (!node) return null;
+            try {
+              return JSON.parse(node.textContent || "null");
+            } catch {
+              return null;
+            }
+          }
+
+          function extractSlug(pathname) {
+            const parts = pathname.split("/").filter(Boolean);
+            const redirectIndex = parts.indexOf("redirect");
+            if (redirectIndex < 0) return "";
+            return parts[redirectIndex + 1] || "";
+          }
+
+          function isAllowedHost(url, allowedHosts) {
+            try {
+              const parsed = new URL(url);
+              if (parsed.protocol !== "https:") return false;
+              return allowedHosts.has(parsed.host);
+            } catch {
+              return false;
+            }
+          }
+
+          function buildAllowedHosts(entries) {
+            const hosts = new Set();
+            for (const entry of entries) {
+              if (!entry || typeof entry.url !== "string") continue;
+              try {
+                const parsed = new URL(entry.url);
+                if (parsed.protocol === "https:" && parsed.host) hosts.add(parsed.host);
+              } catch {
+                // ignore invalid URLs in data
+              }
+            }
+            return hosts;
+          }
+
+          function readLabel(searchParams, entry, destinationUrl) {
+            const override = (searchParams.get("label") || "").trim();
+            if (override) return override;
+            if (entry && typeof entry.label === "string" && entry.label.trim()) return entry.label.trim();
+            const slug = (searchParams.get("slug") || "").trim();
+            if (slug) return slug;
+            try {
+              return new URL(destinationUrl).host;
+            } catch {
+              return "destination";
+            }
+          }
+
+          function copyAttributionParams(fromParams, toUrl) {
+            for (const [key, value] of fromParams.entries()) {
+              if (!key) continue;
+              if (key === "to" || key === "label" || key === "delay" || key === "slug") continue;
+              if (key.startsWith("utm_") || PASS_THROUGH_KEYS.has(key)) {
+                toUrl.searchParams.set(key, value);
+              }
+            }
+          }
+
+          const subtitle = document.getElementById("redirect-subtitle");
+          const message = document.getElementById("redirect-message");
+          const link = document.getElementById("redirect-link");
+
+          const currentUrl = new URL(window.location.href);
+          const slugFromPath = extractSlug(window.location.pathname);
+          const slugFromQuery = (currentUrl.searchParams.get("slug") || "").trim();
+          const slug = slugFromPath || slugFromQuery;
+          if (!slug) {
+            redirectFailure();
+            return;
+          }
+
+          const entries = readJsonScript("redirect-map");
+          const redirectEntries = Array.isArray(entries) ? entries : [];
+          const allowedHosts = buildAllowedHosts(redirectEntries);
+
+          const entry = redirectEntries.find((candidate) => candidate && candidate.slug === slug) || null;
+          const requestedTo = (currentUrl.searchParams.get("to") || "").trim();
+
+          let destination = "";
+          if (entry && typeof entry.url === "string" && entry.url.trim()) {
+            destination = entry.url.trim();
+          }
+          if (requestedTo) {
+            if (isAllowedHost(requestedTo, allowedHosts)) {
+              destination = requestedTo;
+            } else {
+              redirectFailure();
+              return;
+            }
+          }
+          let fallbackToCoaching = false;
+          if (!destination) {
+            fallbackToCoaching = true;
+            destination = FAILURE_URL;
+          }
+
+          let destinationUrl;
+          try {
+            destinationUrl = new URL(destination, window.location.origin);
+          } catch {
+            redirectFailure();
+            return;
+          }
+
+          if (!fallbackToCoaching) {
+            copyAttributionParams(currentUrl.searchParams, destinationUrl);
+          }
+
+          const labelParams = new URLSearchParams(currentUrl.searchParams);
+          if (!labelParams.has("slug") && slug) {
+            labelParams.set("slug", slug);
+          }
+          const label = readLabel(labelParams, entry, destinationUrl.href);
+          if (fallbackToCoaching) {
+            if (subtitle) subtitle.textContent = `Unknown redirect: ${label}`;
+            if (message) message.textContent = `Redirecting you to coaching...`;
+            if (link) link.href = FAILURE_URL;
+          } else {
+            if (subtitle) subtitle.textContent = `Destination: ${label}`;
+            if (message) message.textContent = `You are being redirected to ${label}...`;
+          }
+          if (link) link.href = destinationUrl.href;
+
+          window.setTimeout(() => {
+            window.location.assign(destinationUrl.href);
+          }, REDIRECT_DELAY_MS);
+        })();
+      </script>
+    </div>
+  </div>
+</section>
+
+{{ end }}

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -38,7 +38,17 @@
             const node = document.getElementById(id);
             if (!node) return null;
             try {
-              return JSON.parse(node.textContent || "null");
+              let parsed = JSON.parse(node.textContent || "null");
+              // Hugo's minify pipeline can end up serializing data into a JSON string.
+              // Accept both: array/object OR JSON-string-wrapping-the-real-payload.
+              if (typeof parsed === "string") {
+                try {
+                  parsed = JSON.parse(parsed);
+                } catch {
+                  // ignore
+                }
+              }
+              return parsed;
             } catch {
               return null;
             }

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,12 @@
   force = true
 
 [[redirects]]
+  from = "/redirect/*"
+  to = "/redirect/"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/english/*"
   to = "/404.html"
   status = 410

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -88,6 +88,24 @@ describe('SEO build assertions', () => {
       const pageType = classifyPage(page.relativePath);
       const h1Count = $('h1').length;
 
+      if (page.relativePath === 'redirect/index.html') {
+        const robots = $('meta[name="robots"]').attr('content')?.trim() ?? '';
+        assert(
+          robots === 'noindex,nofollow',
+          `[${page.relativePath}] must include meta robots="noindex,nofollow". Actual value: "${robots || '(missing)'}".`,
+        );
+
+        assert(
+          $('.redirect-spinner').length === 1,
+          `[${page.relativePath}] must render exactly one redirect spinner (.redirect-spinner).`,
+        );
+
+        assert(
+          $('#redirect-link').length === 1,
+          `[${page.relativePath}] must render a fallback redirect link (#redirect-link).`,
+        );
+      }
+
       const title = readRequiredText($, 'title', page.relativePath);
       assert(
         title.includes(siteTitle),


### PR DESCRIPTION
Implements issue #70: branded redirect bridge page to capture Umami analytics before redirecting outbound.

What’s included:
- Netlify rewrite: `/redirect/*` -> `/redirect/` (200) so `/redirect/<slug>` serves the interstitial.
- Hugo page + template for `/redirect/` that:
  - Resolves destination via `data/en/redirects.yml` (slug -> url + label)
  - Optional `?to=` override only when host is allowlisted (derived from YAML destinations)
  - Passes through `utm_*` + `gclid`/`fbclid`/`msclkid`
  - Waits 1800ms to allow Umami pageview to fire, then redirects
  - `noindex,nofollow` on the redirect page
- Branded CSS for the interstitial
- SEO assertion updated to require robots meta on `/redirect/`

How to test in Deploy Preview:
- `/redirect/adplist-coaching`
- `/redirect/adplist-coaching?label=ADPLIST&utm_source=test&utm_medium=test&utm_campaign=test`

Notes:
- `data/en/redirects.yml` currently includes an `adplist-coaching` sample entry; extend as needed.
