### PR TITLE
fix: remove querystring cache busting from fingerprinted assets

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -17,10 +17,9 @@
 
 {{ if and $ahrefsEnabled $ahrefsDataKey (eq hugo.Environment "production") }}
 {{ $ahrefsScript := resources.Get "vendor/ahrefs/analytics.js" | fingerprint "sha384" }}
-{{ $ahrefsScriptURL := printf "%s?v=%s" $ahrefsScript.Permalink ($ahrefsScript.Data.Integrity | urlquery) }}
 <script
   async
-  src="{{ $ahrefsScriptURL }}"
+  src="{{ $ahrefsScript.Permalink }}"
   integrity="{{ $ahrefsScript.Data.Integrity }}"
   data-key="{{ $ahrefsDataKey }}"
 ></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -154,11 +154,10 @@
 	{{ partial "critical-css.html" . }}
 	{{ if gt (len $deferredCssParts) 0 }}
 		{{ $siteCss := $deferredCssParts | resources.Concat "css/site.css" | minify | fingerprint "sha384" }}
-		{{ $siteCssURL := printf "%s?v=%s" $siteCss.Permalink ($siteCss.Data.Integrity | urlquery) }}
-		<link rel="preload" href="{{ $siteCssURL }}" as="style" integrity="{{ $siteCss.Data.Integrity }}">
-		<link rel="stylesheet" href="{{ $siteCssURL }}" integrity="{{ $siteCss.Data.Integrity }}" onload="this.onload=null;this.rel='stylesheet'">
+		<link rel="preload" href="{{ $siteCss.Permalink }}" as="style" integrity="{{ $siteCss.Data.Integrity }}">
+		<link rel="stylesheet" href="{{ $siteCss.Permalink }}" integrity="{{ $siteCss.Data.Integrity }}" onload="this.onload=null;this.rel='stylesheet'">
 		<noscript>
-			<link rel="stylesheet" href="{{ $siteCssURL }}" integrity="{{ $siteCss.Data.Integrity }}">
+			<link rel="stylesheet" href="{{ $siteCss.Permalink }}" integrity="{{ $siteCss.Data.Integrity }}">
 		</noscript>
 	{{ end }}
 

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -18,14 +18,12 @@
 {{ end }}
 {{ if gt (len $vendorJsParts) 0 }}
 	{{ $vendorJs := $vendorJsParts | resources.Concat "js/vendor.js" | minify | fingerprint "sha384" }}
-	{{ $vendorJsURL := printf "%s?v=%s" $vendorJs.Permalink ($vendorJs.Data.Integrity | urlquery) }}
-	<script src="{{ $vendorJsURL }}" integrity="{{ $vendorJs.Data.Integrity }}" defer></script>
+	<script src="{{ $vendorJs.Permalink }}" integrity="{{ $vendorJs.Data.Integrity }}" defer></script>
 {{ end }}
 
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify | fingerprint "sha384"}}
-{{ $scriptURL := printf "%s?v=%s" $script.Permalink ($script.Data.Integrity | urlquery) }}
-<script src="{{ $scriptURL }}" integrity="{{ $script.Data.Integrity }}" defer></script>
+<script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity }}" defer></script>
 
 <!-- cookie -->
 {{ if site.Params.cookies.enable }}

--- a/tests/seo-build.test.mjs
+++ b/tests/seo-build.test.mjs
@@ -175,8 +175,8 @@ describe('SEO build assertions', () => {
       );
       const preloadHref = preloadStyles.first().attr('href')?.trim() ?? '';
       assert(
-        preloadHref.includes('?v='),
-        `[${page.relativePath}] deferred stylesheet preload must include a stable cache-busting query string.`,
+        /\/css\/site\.[^/?"]+\.css$/.test(preloadHref),
+        `[${page.relativePath}] deferred stylesheet preload must use the fingerprinted site stylesheet path without query-string cache busting. Actual href: "${preloadHref}".`,
       );
 
       const deferredStylesheet = $('link[rel="stylesheet"][href*="/css/site."]');
@@ -186,8 +186,8 @@ describe('SEO build assertions', () => {
       );
       const deferredHref = deferredStylesheet.attr('href')?.trim() ?? '';
       assert(
-        deferredHref.includes('?v='),
-        `[${page.relativePath}] combined site stylesheet must include a stable cache-busting query string.`,
+        /\/css\/site\.[^/?"]+\.css$/.test(deferredHref),
+        `[${page.relativePath}] combined site stylesheet must use the fingerprinted site stylesheet path without query-string cache busting. Actual href: "${deferredHref}".`,
       );
       assert(
         preloadHref === deferredHref,
@@ -195,13 +195,14 @@ describe('SEO build assertions', () => {
       );
 
       const noScriptDeferredMatch = html.match(
-        /<noscript>\s*<link rel=stylesheet href="([^"]*\/css\/site\.[^"]*)"/i,
+        /<noscript>\s*<link rel=stylesheet href=(?:"([^"]*\/css\/site\.[^"]*)"|([^\s>]*\/css\/site\.[^\s>]*))/i,
       );
       assert(
         noScriptDeferredMatch,
         `[${page.relativePath}] must include a noscript fallback for the combined site stylesheet bundle.`,
       );
-      const noScriptDeferredHref = noScriptDeferredMatch[1]?.trim() ?? '';
+      const noScriptDeferredHref =
+        noScriptDeferredMatch[1]?.trim() ?? noScriptDeferredMatch[2]?.trim() ?? '';
       assert(
         noScriptDeferredHref === deferredHref,
         `[${page.relativePath}] noscript stylesheet href must match the deferred stylesheet href exactly.`,
@@ -233,8 +234,8 @@ describe('SEO build assertions', () => {
           `[${page.relativePath}] Ahrefs analytics must be served from the local site, not analytics.ahrefs.com. Actual src: "${ahrefsSrc}".`,
         );
         assert(
-          ahrefsSrc.includes('?v='),
-          `[${page.relativePath}] Ahrefs analytics must include a stable cache-busting query string.`,
+          /\/vendor\/ahrefs\/analytics\.[^/?"]+\.js$/.test(ahrefsSrc),
+          `[${page.relativePath}] Ahrefs analytics must use the fingerprinted local asset path without query-string cache busting. Actual src: "${ahrefsSrc}".`,
         );
 
         assertResolvableAssetUrl(
@@ -336,8 +337,8 @@ describe('SEO build assertions', () => {
         .filter(Boolean);
       for (const scriptSrc of fingerprintedScripts) {
         assert(
-          scriptSrc.includes('?v='),
-          `[${page.relativePath}] fingerprinted script assets must include a stable cache-busting query string. Actual src: "${scriptSrc}".`,
+          /\/js\/(vendor|script)\.[^/?"]+\.js$/.test(scriptSrc),
+          `[${page.relativePath}] fingerprinted script assets must use hashed filenames without query-string cache busting. Actual src: "${scriptSrc}".`,
         );
       }
 


### PR DESCRIPTION
## Summary
- stop appending integrity-based `?v=` query strings to fingerprinted CSS and JS assets
- keep cache busting on the hashed filename that Hugo already emits
- update SEO assertions to validate hashed asset paths and tolerate minified `noscript` output

## Why
Production was returning `404` for `site.min...css` when the asset URL included the extra integrity-based query string, even though the same fingerprinted file resolved without it.

## Verification
- `npm run build`
- `npx vitest run tests/seo-build.test.mjs`